### PR TITLE
Fixed date string in Czech translation

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -20,7 +20,7 @@ msgid Date
 msgstr Datum
 
 msgid %b %d %Y
-msgstr %d. %m. %Y
+msgstr %d\. %m\. %Y
 
 msgid Text review
 msgstr Text


### PR DESCRIPTION
Due to DC markdown is necessary to use '\' before '.'