### PR TITLE
guild_id overflowing issue fix

### DIFF
--- a/reviews/database.py
+++ b/reviews/database.py
@@ -169,7 +169,7 @@ class Subject(database.base):
 
     id = Column(Integer, primary_key=True)
     shortcut = Column(String)
-    guild_id = Column(Integer)
+    guild_id = Column(BigInteger)
     category = Column(String)
     name = Column(String)
     reviews = relationship(


### PR DESCRIPTION
Integer is not enough for guild_id. Fixed it by changing it to BigInteger.